### PR TITLE
[Andrew] refresh getTask after editTask

### DIFF
--- a/src/main/java/interface_adapter/task/edit_task/EditTaskPresenter.java
+++ b/src/main/java/interface_adapter/task/edit_task/EditTaskPresenter.java
@@ -2,6 +2,7 @@ package interface_adapter.task.edit_task;
 
 import domains.task.use_case.edit_task.EditTaskOutputBoundary;
 import domains.task.use_case.edit_task.EditTaskOutputData;
+import interface_adapter.task.get_task.GetTaskState;
 import interface_adapter.task.get_task.GetTaskViewModel;
 import interface_adapter.view_model.ViewManagerModel;
 
@@ -22,6 +23,9 @@ public class EditTaskPresenter implements EditTaskOutputBoundary {
         EditTaskState editTaskState = editTaskViewModel.getState();
         editTaskState.setTaskID(editTaskOutputData.getTaskID());
         editTaskViewModel.firePropertyChanged();
+
+        GetTaskState getTaskState = getTaskViewModel.getState();
+        getTaskState.setInitial(true);
         getTaskViewModel.firePropertyChanged();
 
         // On success, switch to the get task view.


### PR DESCRIPTION
# Task Description
GetTaskView is not updated after editTask is performed

## Type of change

Please select options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Solution
Just refresh getTask after editTask is performed

## Relevant documentation

If applicable, add screenshots/sources to help explain your changes.


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules